### PR TITLE
start_capture_rx: Really fix frequency metadata from update_adc_nco

### DIFF
--- a/boards/RFSoC4x2/rfsoc_qsfp_offload/scripts/start_capture_rx.py
+++ b/boards/RFSoC4x2/rfsoc_qsfp_offload/scripts/start_capture_rx.py
@@ -108,7 +108,7 @@ def zmq_cmd_handler(message, data):
             return
         set_param, set_value = args
         if set_param == "freq_metadata": # Change the Center Frequency for metadata purposes
-            set_freq_metadata(int(float(set_value) * 1e3), data)
+            set_freq_metadata(set_value, data)
         elif set_param == "freq_IF": # Change the actual IF frequency without restarting the whole script
             update_adc_nco(set_value, data)
         else:

--- a/boards/RFSoC4x2/rfsoc_qsfp_offload/scripts/start_capture_rx.py
+++ b/boards/RFSoC4x2/rfsoc_qsfp_offload/scripts/start_capture_rx.py
@@ -77,8 +77,7 @@ def update_adc_nco(freq_mhz, data):
             adc_tile.blocks[block].UpdateEvent(xrfdc.EVENT_MIXER)
             adc_tile.SetupFIFO(True)
 
-        # frequency metadata tag in kHz
-        set_freq_metadata(freq_hz / 1e3, data)
+        set_freq_metadata(freq_hz, data)
         logging.info(f"ADC mixer and metadata updated to {freq_mhz:.2f} MHz")
     except Exception as e:
         logging.error(f"Failed to update full ADC mixer configuration: {e}")


### PR DESCRIPTION
It *does* want Hz here, and gets converted to kHz in set_freq_metadata.

Also:

start_capture_rx: Fix set_freq_metadata command taking kHz instead of Hz

On the client side, the variable names indicate that the
set_freq_metadata message should be given in Hz, but it is currently
given in kHz. This is confusing, since the set_freq_metadata function on
the RFSoC side takes it in Hz. Standardize everything to Hz.